### PR TITLE
Support apple universal links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+node_modules
+.serverless
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# production
+/build
+
+# misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The REAL-Website
 
 ## Initialization
 
-Run `yarn init` in the root of the repository to install required packages.
+Run `yarn install` in the root of the repository to install required packages.
 
 For deployment, you will need command-line access to the AWS environment you wish to deploy to. This is usually this is done by setting up the appropriate [AWS credentials file](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html).
 

--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -1,0 +1,16 @@
+{
+  "applinks": {
+    "apps": [],
+    "details": [{
+      "appID": "YA5Y244F5C.app.real.mobile",
+      "paths": [
+        "/confirm/*",
+        "/user/*",
+        "/post/*",
+        "/comment/*",
+        "/chat/*",
+        "/chatMessage/*"
+      ]
+    }]
+  }
+}

--- a/serverless.yml
+++ b/serverless.yml
@@ -34,6 +34,7 @@ custom:
   cloudfrontInvalidate:
     distributionIdKey: CloudFrontWebsiteDistributionId
     items:
+      - /.well-known/apple-app-site-association
       - /favicon.ico
       - /index.html
       - /manifest.json


### PR DESCRIPTION
This PR adds support for [apple universal links](https://developer.apple.com/documentation/uikit/inter-process_communication/allowing_apps_and_websites_to_link_to_your_content/enabling_universal_links) by adding the `.well-known/apple-app-site-association` file.

Unlike the old 'url scheme' deep links we're currently using (ie `real.app://...`), these links will work in gmail, and anywhere else a normal `https://...` link works. Universal links are just standard links, ie `https://real.app/...`

Once this is merged and deployed to our production website, our next steps should be:

1. deploy new frontend release that can handle 'confirm your email' links in both of these formats:
    - the old 'url scheme' links that we're currently using
    - these new universal links
1. deploy new backend release that emits 'confirm your email' links as universal links
1. deploy new frontend release that drops support for the old 'url scheme' link format

Also included in this PR is a fix to documentation, and adding a `.gitignore` file.