### PR TITLE
Remove CNAMEs from CloudFront distribution

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -84,9 +84,6 @@ resources:
       Type: AWS::CloudFront::Distribution
       Properties:
         DistributionConfig:
-          Aliases:
-            - real.app
-            - www.real.app
           ViewerCertificate:
             AcmCertificateArn: arn:aws:acm:us-east-1:128661475706:certificate/7226b47a-6f3c-4300-908f-afd83da2aaaa
             SslSupportMethod: sni-only


### PR DESCRIPTION
This PR removes aliases to `real.app` and `www.real.app` so they can be used for the new Real App Platform website.